### PR TITLE
Fix typo in variable name

### DIFF
--- a/network_main.ipynb
+++ b/network_main.ipynb
@@ -256,7 +256,7 @@
     "            testX, testy = filterX[test_ind], filterY[test_ind]\n",
     "\n",
     "            trainX, validateX, testX = generate_tensors(trainX, validateX, testX, dtype=x_dtype)\n",
-    "            trainy, validtey, testy = generate_tensors(trainy, validatey, testy, dtype=y_dtype)\n",
+    "            trainy, validatey, testy = generate_tensors(trainy, validatey, testy, dtype=y_dtype)\n",
     "\n",
     "            torch.cuda.empty_cache()\n",
     "            ckp = Checkpoint(dirname=ckp_dirname)\n",


### PR DESCRIPTION
Changed `validtey` to `validatey` at network_main.ipynb